### PR TITLE
Update quip-pathdb.yml to fix MongoDB key issue

### DIFF
--- a/quip-pathdb.yml
+++ b/quip-pathdb.yml
@@ -61,7 +61,7 @@ services:
     volumes:
       - ./data:/data
   heatmaploader:
-    build: "https://github.com/SBU-BMI/uploadHeatmaps.git#v1.5.4"
+    build: "https://github.com/SBU-BMI/uploadHeatmaps.git#v1.5.5"
     container_name: quip-hmloader
     volumes:
       - ./data:/mnt/data/


### PR DESCRIPTION
SBU-BMI/uploadHeatmaps was updated from v1.5.4 to v1.5.5 to fix MongoDB key issues. This PR updates the quip-pathdb.yml file to uploadHeatmaps v1.5.5.